### PR TITLE
Fix worker label

### DIFF
--- a/internal/cluster/join.go
+++ b/internal/cluster/join.go
@@ -94,7 +94,7 @@ func (c *Cluster) Join(ctx context.Context, opts JoinOptions) error {
 		labels[k] = v
 	}
 	if !opts.IsControlPlane {
-		labels["node-role.kubernetes.io/worker"] = "worker"
+		labels["node-role.kubernetes.io/worker"] = ""
 	}
 
 	if len(labels) > 0 {


### PR DESCRIPTION
The correct label for workers is node-role.kubernetes.io/worker="" not node-role.kubernetes.io/worker="worker"

## Summary by Sourcery

Bug Fixes:
- Fix worker node labeling by setting node-role.kubernetes.io/worker to an empty string instead of "worker" when joining non-control-plane nodes.