### PR TITLE
Add the ability to execute any command via ssh 

### DIFF
--- a/cmd/bink/main.go
+++ b/cmd/bink/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -53,6 +54,9 @@ Common workflows:
 
   # SSH into a node
   bink node ssh node1
+
+  # Run a command on a node
+  bink node ssh node1 -- uname -a
 
   # Tear down
   bink cluster stop --remove-data`,
@@ -120,6 +124,10 @@ func initConfig() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
+		var exitErr *cli.ExitCodeError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/internal/cli/exitcode.go
+++ b/internal/cli/exitcode.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 The bink Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import "fmt"
+
+type ExitCodeError struct {
+	Code int
+}
+
+func (e *ExitCodeError) Error() string {
+	return fmt.Sprintf("exit code %d", e.Code)
+}

--- a/internal/cli/node/ssh.go
+++ b/internal/cli/node/ssh.go
@@ -6,6 +6,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -18,17 +19,42 @@ import (
 
 func newSSHCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ssh <node-name>",
+		Use:   "ssh <node-name> [-- command [args...]]",
 		Short: "SSH into a node's VM",
-		Long:  "Start an interactive SSH session to a node's VM",
+		Long:  "Start an interactive SSH session to a node's VM, or run a command and exit.",
 		Example: `  # SSH into the control-plane node
   bink node ssh node1
 
   # SSH into a worker node in a named cluster
-  bink node ssh node2 --cluster-name dev`,
-		Args:              cobra.ExactArgs(1),
-		ValidArgsFunction: cli.CompleteNodeNames,
-		RunE:              runSSH,
+  bink node ssh node2 --cluster-name dev
+
+  # Run a command on a node
+  bink node ssh node1 -- uname -a
+
+  # Run kubectl on the control-plane node
+  bink node ssh node1 -- sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get nodes`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			dash := cmd.ArgsLenAtDash()
+			switch {
+			case dash == -1 && len(args) == 1:
+				return nil
+			case dash == 1:
+				return nil
+			case dash == -1 && len(args) == 0:
+				return fmt.Errorf("requires a node name")
+			case dash == -1:
+				return fmt.Errorf("extra arguments %v; use -- to separate the remote command", args[1:])
+			default:
+				return fmt.Errorf("exactly one node name is required before --")
+			}
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return cli.CompleteNodeNames(cmd, args, toComplete)
+		},
+		RunE: runSSH,
 	}
 
 	return cmd
@@ -40,19 +66,25 @@ func runSSH(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	logger := logrus.New()
 
-	// Get cluster name
 	clusterName := viper.GetString("cluster.name")
-
-	// Get node IP for display
-	clusterIP := node.CalculateClusterIP(clusterName, nodeName)
-
-	// Create SSH client
 	sshClient := ssh.NewClientForNode(clusterName, nodeName, logger)
 
+	if cmd.ArgsLenAtDash() == 1 {
+		command := strings.Join(args[1:], " ")
+		exitCode, err := sshClient.ExecStream(ctx, command)
+		if err != nil {
+			return fmt.Errorf("failed to execute command on %s: %w", nodeName, err)
+		}
+		if exitCode != 0 {
+			return &cli.ExitCodeError{Code: exitCode}
+		}
+		return nil
+	}
+
+	clusterIP := node.CalculateClusterIP(clusterName, nodeName)
 	fmt.Printf("Connecting to %s (SSH: %s:%s, cluster: %s) as user core\n",
 		nodeName, ssh.DefaultSSHHost, ssh.DefaultSSHPort, clusterIP)
 
-	// Start interactive session
 	if err := sshClient.Interactive(ctx); err != nil {
 		return fmt.Errorf("failed to connect to %s: %w", nodeName, err)
 	}

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -405,6 +405,41 @@ func (c *Client) ContainerExecQuiet(ctx context.Context, name string, cmd []stri
 	return nil
 }
 
+func (c *Client) ContainerExecStream(ctx context.Context, name string, cmd []string) (int, error) {
+	if err := c.ensureConnection(); err != nil {
+		return -1, err
+	}
+
+	logrus.Debugf("Executing (stream): %s %s", name, strings.Join(cmd, " "))
+
+	execConfig := &handlers.ExecCreateConfig{}
+	execConfig.Cmd = cmd
+	execConfig.AttachStdout = true
+	execConfig.AttachStderr = true
+
+	sessionID, err := containers.ExecCreate(c.withCtx(ctx), name, execConfig)
+	if err != nil {
+		return -1, fmt.Errorf("creating exec session: %w", err)
+	}
+
+	startOptions := new(containers.ExecStartAndAttachOptions).
+		WithOutputStream(os.Stdout).
+		WithErrorStream(os.Stderr).
+		WithAttachOutput(true).
+		WithAttachError(true)
+
+	if err := containers.ExecStartAndAttach(c.withCtx(ctx), sessionID, startOptions); err != nil {
+		return -1, fmt.Errorf("executing command: %w", err)
+	}
+
+	inspectData, err := containers.ExecInspect(c.withCtx(ctx), sessionID, nil)
+	if err != nil {
+		return -1, fmt.Errorf("inspecting exec session: %w", err)
+	}
+
+	return inspectData.ExitCode, nil
+}
+
 func (c *Client) ContainerExecInteractive(ctx context.Context, name string, cmd []string) error {
 	if err := c.ensureConnection(); err != nil {
 		return err

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -85,6 +85,17 @@ func (c *Client) ExecWithOutput(ctx context.Context, command string) error {
 	return nil
 }
 
+// ExecStream executes a command via SSH, streaming output to stdout/stderr without TTY.
+// Returns the remote command's exit code.
+func (c *Client) ExecStream(ctx context.Context, command string) (int, error) {
+	sshArgs := c.buildSSHArgs(command)
+	execCmd := append([]string{"ssh"}, sshArgs...)
+
+	c.logger.Debugf("Running in container %s: %s", c.containerName, strings.Join(execCmd, " "))
+
+	return c.podmanClient.ContainerExecStream(ctx, c.containerName, execCmd)
+}
+
 // Interactive starts an interactive SSH session
 func (c *Client) Interactive(ctx context.Context) error {
 	sshArgs := c.buildSSHArgs("")

--- a/test/integration/cluster_test.go
+++ b/test/integration/cluster_test.go
@@ -86,6 +86,18 @@ var _ = Describe("Cluster Lifecycle", func() {
 			_, hasCP := n1.Labels["node-role.kubernetes.io/control-plane"]
 			Expect(hasCP).To(BeTrue(), "%s should have control-plane role", customNodeName)
 
+			By("Verifying bink node ssh can run a command on the node")
+			sshCmd := helpers.BinkCmd("node", "ssh", customNodeName, "--cluster-name", clusterName, "--", "uname", "-n")
+			sshSession := helpers.RunCommand(sshCmd)
+			Expect(sshSession.ExitCode()).To(Equal(0))
+			sshOutput := string(sshSession.Out.Contents())
+			Expect(sshOutput).To(ContainSubstring(customNodeName), "SSH command output should contain the node hostname")
+
+			By("Verifying bink node ssh propagates non-zero exit codes")
+			failCmd := helpers.BinkCmd("node", "ssh", customNodeName, "--cluster-name", clusterName, "--", "exit", "42")
+			failSession := helpers.RunCommand(failCmd)
+			Expect(failSession.ExitCode()).To(Equal(42), "SSH command should propagate the remote exit code")
+
 			By("Verifying Calico CNI is running")
 			helpers.WaitForPodReady(kubeClient, "kube-system", "k8s-app=calico-node", 3*time.Minute)
 


### PR DESCRIPTION
Fixes: #28

## Summary by Sourcery

Allow ssh subcommand to execute non-interactive commands on nodes and propagate their exit codes.

New Features:
- Support running arbitrary commands via `bink node ssh` and exiting after completion.

Enhancements:
- Extend Podman and SSH clients with streaming exec support for non-interactive command execution.
- Adjust ssh CLI argument handling and completion to accept additional command arguments.
- Update main command error handling to exit with propagated SSH command exit codes.

Documentation:
- Document command-execution usage of `bink node ssh` in command help and top-level CLI examples.

Tests:
- Add integration coverage to verify `bink node ssh` can run commands on a node and return expected output.