### PR TITLE
api expose: print sourceable export line to stdout

### DIFF
--- a/internal/cli/api/expose.go
+++ b/internal/cli/api/expose.go
@@ -123,11 +123,17 @@ func RunExpose(ctx context.Context, logger *logrus.Logger, nodeName, kubeconfigP
 		return fmt.Errorf("writing kubeconfig: %w", err)
 	}
 
+	absPath, err := filepath.Abs(kubeconfigPath)
+	if err != nil {
+		absPath = kubeconfigPath
+	}
+	fmt.Printf("export KUBECONFIG=%s\n", absPath)
+
 	logger.Infof("Kubeconfig generated at %s", kubeconfigPath)
 	logger.Infof("   Server URL: https://localhost:%d", hostPort)
 	logger.Info("")
 	logger.Info("Usage:")
-	logger.Infof("  export KUBECONFIG=%s", kubeconfigPath)
+	logger.Infof("  eval \"$(bink api expose)\"")
 	logger.Info("  kubectl get nodes")
 	logger.Info("")
 

--- a/internal/cli/cluster/start.go
+++ b/internal/cli/cluster/start.go
@@ -202,10 +202,7 @@ func runStart(ctx context.Context, logger *logrus.Logger, nodeName string, nodeI
 		}
 	} else {
 		logger.Info("Next steps:")
-		logger.Info("  ./bink api expose")
-		logger.Info("")
-		logger.Info("Then use:")
-		logger.Info("  export KUBECONFIG=./kubeconfig")
+		logger.Infof("  eval \"$(bink api expose)\"")
 		logger.Info("  kubectl get nodes")
 	}
 	logger.Info("")

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -79,8 +79,7 @@ func (c *Client) ExecWithOutput(ctx context.Context, command string) error {
 		return fmt.Errorf("ssh exec failed: %w", err)
 	}
 
-	// Write output to stdout (ContainerExec buffers output, so we write it here)
-	fmt.Fprint(os.Stdout, output)
+	fmt.Fprint(os.Stderr, output)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #29

## Summary by Sourcery

Print a shell-exportable KUBECONFIG line to stdout when exposing the API and update CLI guidance to use eval with `bink api expose`, while routing SSH exec command output to stderr instead of stdout.

Enhancements:
- Print an absolute-path KUBECONFIG export line to stdout from `bink api expose` for easier shell integration.
- Update API expose and cluster start CLI messages to recommend `eval "$(bink api expose)"` usage.
- Change SSH client exec output to be written to stderr instead of stdout.