### PR TITLE
Various patches to make non-default cluster name easier to use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,6 @@ kubectl get nodes
 
 Flags:
 - `--role worker|control-plane` (default: `worker`)
-- `--control-plane node1` (which node to join against, default: `node1`)
 - `--memory` VM RAM in MB
 
 ### SSH into a Node

--- a/cmd/bink/main.go
+++ b/cmd/bink/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/bootc-dev/bink/internal/cli"
 	"github.com/bootc-dev/bink/internal/cli/api"
@@ -115,6 +116,7 @@ func initConfig() {
 	}
 
 	viper.SetEnvPrefix("BINK")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err == nil {

--- a/cmd/bink/main.go
+++ b/cmd/bink/main.go
@@ -83,7 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.bink/config.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "debug output")
-	rootCmd.PersistentFlags().String("cluster-name", config.DefaultNetworkName, "cluster name")
+	rootCmd.PersistentFlags().StringP("cluster-name", "c", config.DefaultNetworkName, "cluster name")
 
 	viper.BindPFlag("cluster.name", rootCmd.PersistentFlags().Lookup("cluster-name"))
 	viper.BindPFlag("logging.verbose", rootCmd.PersistentFlags().Lookup("verbose"))

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -70,36 +70,4 @@ func CompleteNodeNames(cmd *cobra.Command, args []string, toComplete string) ([]
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
-func CompleteControlPlaneNodes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := podman.NewClient()
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
 
-	ctx := cmd.Context()
-	clusterName := viper.GetString("cluster.name")
-	containers, err := client.ContainerList(ctx, config.LabelFilter(config.LabelClusterName, clusterName))
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-
-	var names []string
-	for _, ctr := range containers {
-		component, _ := client.ContainerInspect(ctx, ctr, config.LabelInspectFormat(config.LabelComponent))
-		if component != "" {
-			continue
-		}
-		role, _ := client.ContainerInspect(ctx, ctr, config.LabelInspectFormat(config.LabelNodeRole))
-		if role != "control-plane" {
-			continue
-		}
-		nodeName, err := client.ContainerInspect(ctx, ctr, config.LabelInspectFormat(config.LabelNodeName))
-		if err != nil || nodeName == "" {
-			continue
-		}
-		if strings.HasPrefix(nodeName, toComplete) {
-			names = append(names, nodeName)
-		}
-	}
-	return names, cobra.ShellCompDirectiveNoFileComp
-}

--- a/internal/cli/node/add.go
+++ b/internal/cli/node/add.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/bootc-dev/bink/internal/cli"
 	"github.com/bootc-dev/bink/internal/cluster"
 	"github.com/bootc-dev/bink/internal/config"
 	"github.com/bootc-dev/bink/internal/dns"
@@ -22,7 +21,6 @@ import (
 )
 
 func newAddCmd() *cobra.Command {
-	var controlPlane string
 	var nodeImage string
 	var role string
 	var memory int
@@ -49,11 +47,10 @@ func newAddCmd() *cobra.Command {
 				return err
 			}
 			logger := logrus.New()
-			return runAdd(cmd.Context(), args[0], controlPlane, nodeImage, role, memory, maxMemory, hostNetworkPopulator, labels, logger)
+			return runAdd(cmd.Context(), args[0], nodeImage, role, memory, maxMemory, hostNetworkPopulator, labels, logger)
 		},
 	}
 
-	cmd.Flags().StringVarP(&controlPlane, "control-plane", "c", "node1", "Control plane node name")
 	cmd.Flags().StringVar(&nodeImage, "node-image", config.DefaultNodeImage, "Container image containing base VM images")
 	cmd.Flags().StringVarP(&role, "role", "r", "worker", "Node role: worker or control-plane")
 	cmd.Flags().IntVar(&memory, "memory", 0, "VM memory in MB (0 = use role default: 1900 for control-plane, 768 for worker)")
@@ -64,8 +61,6 @@ func newAddCmd() *cobra.Command {
 	cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"worker", "control-plane"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	cmd.RegisterFlagCompletionFunc("control-plane", cli.CompleteControlPlaneNodes)
-
 	return cmd
 }
 
@@ -89,7 +84,7 @@ func parseLabels(labelFlags []string) (map[string]string, error) {
 	return labels, nil
 }
 
-func runAdd(ctx context.Context, nodeName, controlPlane, nodeImage, role string, memory int, maxMemory int, hostNetworkPopulator bool, labels map[string]string, logger *logrus.Logger) error {
+func runAdd(ctx context.Context, nodeName, nodeImage, role string, memory int, maxMemory int, hostNetworkPopulator bool, labels map[string]string, logger *logrus.Logger) error {
 	// Validate and convert role to boolean
 	var isControlPlane bool
 	switch role {
@@ -132,9 +127,9 @@ func runAdd(ctx context.Context, nodeName, controlPlane, nodeImage, role string,
 	}
 
 	// Auto-detect the control-plane node name from container labels
-	discovered, err := findControlPlaneNode(ctx, podmanClient, clusterName, "")
-	if err == nil {
-		controlPlane = discovered
+	controlPlane, err := findControlPlaneNode(ctx, podmanClient, clusterName, "")
+	if err != nil {
+		return fmt.Errorf("auto-detecting control-plane node: %w", err)
 	}
 
 	// Ensure images volume exists for this node image version


### PR DESCRIPTION
See individual commits.

Motivated by bootc-operator not using the default bink cluster name `podman`.

## Summary by Sourcery

Improve configurability and usability of non-default cluster names in the CLI.

New Features:
- Allow setting the cluster name via the short -c flag as well as --cluster-name.
- Support mapping dotted config keys like cluster.name from environment variables using BINK_*-style names.

Enhancements:
- Automatically detect the control-plane node when adding a node instead of requiring a --control-plane flag.
- Simplify CLI completion helpers by removing the dedicated control-plane node completion function.

Documentation:
- Update node addition documentation to reflect automatic control-plane detection and the removal of the --control-plane flag.