### PR TITLE
Make the bootc image point to the public image

### DIFF
--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -6,8 +6,9 @@ DISK_SIZE ?= 10G
 BUILD_MEMORY ?= 4G
 
 IMAGE_TAG ?= v$(KUBE_MINOR)-fedora-$(FEDORA_VERSION)
-BOOTC_IMAGE ?= localhost/bink-node:$(IMAGE_TAG)
-NODE_IMAGE ?= localhost/bink-node:$(IMAGE_TAG)-disk
+REGISTRY ?= ghcr.io/alicefr/bink
+BOOTC_IMAGE ?= $(REGISTRY)/bink-node:$(IMAGE_TAG)
+NODE_IMAGE ?= $(REGISTRY)/bink-node:$(IMAGE_TAG)-disk
 
 # Build the OCI bootc image (k8s + cri-o)
 build-bootc-image:


### PR DESCRIPTION
Tag the image with the public registry. In this way, the image embedded in the bootc disk image now points to:

bootc status
● Booted image: ghcr.io/alicefr/bink/bink-node:v1.35-fedora-44
        Digest: sha256:b1dd0021b320fd9220749c43faee982c83592af501b2b74d5e87607ec77dbe39 (amd64)
     Timestamp: 2026-06-03T11:47:46Z

## Summary by Sourcery

Update Fedora node image Makefile to publish bootc and disk images to a configurable public container registry instead of a local one.

Enhancements:
- Introduce a REGISTRY variable defaulting to the public ghcr.io/alicefr/bink registry for image references in the Fedora node image Makefile.

Build:
- Change BOOTC_IMAGE and NODE_IMAGE tags to use the configurable public REGISTRY rather than localhost for built images.