### PR TITLE
Fix CI image push by resolving env var conflict with Makefile

### DIFF
--- a/.github/workflows/build-node-image.yaml
+++ b/.github/workflows/build-node-image.yaml
@@ -17,8 +17,8 @@ on:
         type: boolean
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/node
+  PUSH_REGISTRY: ghcr.io/alicefr/bink
+  PUSH_IMAGE: node
 
 jobs:
   build:
@@ -38,7 +38,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
-        run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ${{ env.REGISTRY }}
+        run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: Build bootc image
         working-directory: node-images/fedora
@@ -58,19 +58,21 @@ jobs:
 
       - name: Tag and push
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
+        working-directory: node-images/fedora
         run: |
+          TAG=${{ steps.meta.outputs.tag }}
+          BOOTC_SRC=$(make -s print-bootc-image)
+          DISK_SRC=$(make -s print-node-image)
+          PUSH_DEST=${{ env.PUSH_REGISTRY }}/${{ env.PUSH_IMAGE }}
+
           # push bootc image under both :latest and versioned tags
-          podman tag localhost/bink-node:${{ steps.meta.outputs.tag }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
-          podman push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
-          podman tag localhost/bink-node:${{ steps.meta.outputs.tag }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          podman push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          podman tag ${BOOTC_SRC} ${PUSH_DEST}:${TAG}
+          podman push ${PUSH_DEST}:${TAG}
+          podman tag ${BOOTC_SRC} ${PUSH_DEST}:latest
+          podman push ${PUSH_DEST}:latest
 
           # push disk image under both :latest-disk and versioned tags
-          podman tag localhost/bink-node:${{ steps.meta.outputs.tag }}-disk \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}-disk
-          podman push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}-disk
-          podman tag localhost/bink-node:${{ steps.meta.outputs.tag }}-disk \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-disk
-          podman push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-disk
+          podman tag ${DISK_SRC} ${PUSH_DEST}:${TAG}-disk
+          podman push ${PUSH_DEST}:${TAG}-disk
+          podman tag ${DISK_SRC} ${PUSH_DEST}:latest-disk
+          podman push ${PUSH_DEST}:latest-disk

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -7,8 +7,8 @@ BUILD_MEMORY ?= 4G
 
 IMAGE_TAG ?= v$(KUBE_MINOR)-fedora-$(FEDORA_VERSION)
 REGISTRY ?= ghcr.io/alicefr/bink
-BOOTC_IMAGE ?= $(REGISTRY)/bink-node:$(IMAGE_TAG)
-NODE_IMAGE ?= $(REGISTRY)/bink-node:$(IMAGE_TAG)-disk
+BOOTC_IMAGE ?= $(REGISTRY)/node:$(IMAGE_TAG)
+NODE_IMAGE ?= $(REGISTRY)/node:$(IMAGE_TAG)-disk
 
 # Build the OCI bootc image (k8s + cri-o)
 build-bootc-image:
@@ -49,6 +49,12 @@ build-disk-image: build-bootc-image
 
 print-image-tag:
 	@echo $(IMAGE_TAG)
+
+print-bootc-image:
+	@echo $(BOOTC_IMAGE)
+
+print-node-image:
+	@echo $(NODE_IMAGE)
 
 clean:
 	@echo "=== Cleaning up ==="


### PR DESCRIPTION
The workflow's REGISTRY env var was overriding the Makefile's REGISTRY ?= default, causing images to be built with wrong names. Rename workflow env vars to PUSH_REGISTRY/PUSH_IMAGE, query the Makefile for actual built image names, and rename bink-node to node.

## Summary by Sourcery

Resolve container image naming and registry conflicts between the CI workflow and the Fedora node image Makefile.

Bug Fixes:
- Prevent CI from overriding the Makefile's REGISTRY default so images are pushed to the correct registry and repository.

Enhancements:
- Align image names from bink-node to node across the Makefile and workflow, and query the Makefile for final image references before tagging and pushing.