### PR TITLE
Update node image

### DIFF
--- a/node-images/fedora/Containerfile
+++ b/node-images/fedora/Containerfile
@@ -25,6 +25,7 @@ RUN /usr/libexec/bootc-base-imagectl build-rootfs \
     --install dnsmasq \
     --install bubblewrap \
     --install sudo \
+    --install vim-minimal \
     /target-rootfs
 
 FROM scratch AS root

--- a/node-images/fedora/Containerfile.disk
+++ b/node-images/fedora/Containerfile.disk
@@ -25,6 +25,10 @@ RUN podman run --rm ${BOOTC_IMAGE} kubeadm config images list > /output/images.t
 
 FROM scratch
 ARG KUBE_MINOR=1.35
+ARG BOOTC_IMAGE
+ARG BOOTC_DIGEST
 LABEL bink.kubeadm-version=${KUBE_MINOR}
+LABEL bink.bootc-image=${BOOTC_IMAGE}
+LABEL bink.bootc-image-digest=${BOOTC_DIGEST}
 COPY --from=builder /output/disk.qcow2 /disk.qcow2
 COPY --from=builder /output/images.txt /images.txt

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -27,6 +27,7 @@ build-bootc-image:
 build-disk-image: build-bootc-image
 	@echo "=== Building node image with qcow2 disk ==="
 	STORAGE_PATH=$$(podman info --format '{{.Store.GraphRoot}}') && \
+	BOOTC_DIGEST=$$(podman inspect --format '{{.Digest}}' $(BOOTC_IMAGE)) && \
 	podman build \
 		--cap-add=SYS_ADMIN \
 		--cap-add=DAC_READ_SEARCH \
@@ -40,6 +41,7 @@ build-disk-image: build-bootc-image
 		--build-arg DISK_SIZE="$(DISK_SIZE)" \
 		--build-arg MEMORY="$(BUILD_MEMORY)" \
 		--build-arg KUBE_MINOR="$(KUBE_MINOR)" \
+		--build-arg BOOTC_DIGEST="$$BOOTC_DIGEST" \
 		-t $(NODE_IMAGE) \
 		-f Containerfile.disk \
 		.


### PR DESCRIPTION
Add `vim` and the label with the cluster node image and digest

## Summary by Sourcery

Update the Fedora node image build to embed the bootc image digest and include vim in the node image.

New Features:
- Include vim-minimal in the Fedora-based node image for basic in-container text editing.

Enhancements:
- Capture the bootc image digest during build and pass it into the node image build as a build argument for labeling or metadata.