### PR TITLE
Add jq to the cluster image

### DIFF
--- a/node-images/fedora/Containerfile
+++ b/node-images/fedora/Containerfile
@@ -26,6 +26,7 @@ RUN /usr/libexec/bootc-base-imagectl build-rootfs \
     --install bubblewrap \
     --install sudo \
     --install vim-minimal \
+    --install jq \
     /target-rootfs
 
 FROM scratch AS root


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Include jq in the Fedora node image to make JSON processing tools available in the environment.