### PR TITLE
node-images/fedora: add less to the node image

### DIFF
--- a/node-images/fedora/Containerfile
+++ b/node-images/fedora/Containerfile
@@ -27,6 +27,7 @@ RUN /usr/libexec/bootc-base-imagectl build-rootfs \
     --install sudo \
     --install vim-minimal \
     --install jq \
+    --install less \
     /target-rootfs
 
 FROM scratch AS root


### PR DESCRIPTION
Install the 'less' pager in the Fedora node image. E.g. when using `journalctl`, without a pager it just directly dumps everything to the terminal.

Assisted-by: Pi (Claude Opus 4.6)

## Summary by Sourcery

New Features:
- Include the less pager in the Fedora node image for paginated command output.