### PR TITLE
Fix control-plane join failing with empty certificate key

### DIFF
--- a/internal/cluster/init.go
+++ b/internal/cluster/init.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strings"
 	"text/template"
 	"time"
 
@@ -25,13 +26,15 @@ var calicoManifest []byte
 var kubeadmConfigTemplate = template.Must(template.New("kubeadm-config").Parse(kubeadmConfigTmpl))
 
 type kubeadmConfigParams struct {
-	AdvertiseAddress string
+	AdvertiseAddress  string
+	KubernetesVersion string
 }
 
 // InitOptions holds options for cluster initialization
 type InitOptions struct {
-	NodeName string
-	Timeout  time.Duration
+	NodeName          string
+	KubernetesVersion string
+	Timeout           time.Duration
 }
 
 // Init initializes a Kubernetes cluster on the control plane node
@@ -60,6 +63,15 @@ func (c *Cluster) Init(ctx context.Context, opts InitOptions) error {
 	// Create SSH client
 	sshClient := ssh.NewClientForNode(c.name, nodeName, c.logger)
 
+	// Query the exact kubeadm version from the VM so the config pins it
+	// and prevents kubeadm from doing a remote version lookup.
+	kubeVersion := opts.KubernetesVersion
+	if kubeVersion == "" {
+		if out, err := sshClient.Exec(ctx, "kubeadm version -o short"); err == nil {
+			kubeVersion = strings.TrimSpace(out)
+		}
+	}
+
 	// Create kubeadm config in container
 	c.logger.Info("Creating kubeadm config file...")
 	clusterLabel := c.name
@@ -67,7 +79,7 @@ func (c *Cluster) Init(ctx context.Context, opts InitOptions) error {
 		clusterLabel = config.DefaultNetworkName
 	}
 	containerName := fmt.Sprintf("k8s-%s-%s", clusterLabel, nodeName)
-	if err := c.createKubeadmConfig(ctx, containerName, clusterIP); err != nil {
+	if err := c.createKubeadmConfig(ctx, containerName, clusterIP, kubeVersion); err != nil {
 		return fmt.Errorf("failed to create kubeadm config: %w", err)
 	}
 
@@ -188,10 +200,11 @@ func (c *Cluster) waitForCalicoCNI(ctx context.Context, sshClient *ssh.Client) e
 }
 
 // createKubeadmConfig creates the kubeadm config file in the container
-func (c *Cluster) createKubeadmConfig(ctx context.Context, containerName string, advertiseAddress string) error {
+func (c *Cluster) createKubeadmConfig(ctx context.Context, containerName string, advertiseAddress string, kubernetesVersion string) error {
 	var buf bytes.Buffer
 	if err := kubeadmConfigTemplate.Execute(&buf, kubeadmConfigParams{
-		AdvertiseAddress: advertiseAddress,
+		AdvertiseAddress:  advertiseAddress,
+		KubernetesVersion: kubernetesVersion,
 	}); err != nil {
 		return fmt.Errorf("failed to render kubeadm config: %w", err)
 	}

--- a/internal/cluster/join.go
+++ b/internal/cluster/join.go
@@ -135,19 +135,20 @@ func (c *Cluster) Join(ctx context.Context, opts JoinOptions) error {
 // generateJoinCommand generates a fresh join command from the control plane
 func (c *Cluster) generateJoinCommand(ctx context.Context, cpSSHClient *ssh.Client, isControlPlane bool) (string, error) {
 	if isControlPlane {
-		// For control-plane nodes, we need to upload certificates and get the certificate key
+		// Generate a certificate key, then upload certs encrypted with that key
 		c.logger.Info("Uploading certificates for control-plane join...")
-		certKeyOutput, err := cpSSHClient.Exec(ctx, "sudo kubeadm init phase upload-certs --upload-certs 2>/dev/null | tail -1")
+		certKeyOutput, err := cpSSHClient.Exec(ctx, "sudo kubeadm certs certificate-key")
 		if err != nil {
-			return "", fmt.Errorf("failed to upload certificates: %w", err)
+			return "", fmt.Errorf("failed to generate certificate key: %w", err)
 		}
-
 		certificateKey := strings.TrimSpace(certKeyOutput)
 		if certificateKey == "" {
 			return "", fmt.Errorf("certificate key is empty")
 		}
 
-		c.logger.Infof("Certificate key: %s", certificateKey)
+		if _, err := cpSSHClient.Exec(ctx, fmt.Sprintf("sudo kubeadm init phase upload-certs --upload-certs --certificate-key %s", certificateKey)); err != nil {
+			return "", fmt.Errorf("failed to upload certificates: %w", err)
+		}
 
 		// Generate join command with control-plane flag
 		output, err := cpSSHClient.Exec(ctx, "sudo kubeadm token create --print-join-command")

--- a/internal/cluster/join.go
+++ b/internal/cluster/join.go
@@ -146,7 +146,22 @@ func (c *Cluster) generateJoinCommand(ctx context.Context, cpSSHClient *ssh.Clie
 			return "", fmt.Errorf("certificate key is empty")
 		}
 
-		if _, err := cpSSHClient.Exec(ctx, fmt.Sprintf("sudo kubeadm init phase upload-certs --upload-certs --certificate-key %s", certificateKey)); err != nil {
+		// Write a temp config that includes certificateKey and
+		// kubernetesVersion, then pass --config to upload-certs.
+		// --config and --certificate-key are mutually exclusive, so the
+		// key must be in the config file. Setting kubernetesVersion
+		// prevents kubeadm from fetching it from dl.k8s.io — that
+		// remote call eats into the 10s internal timeout and causes
+		// "rate: Wait(n=1) would exceed context deadline".
+		writeCmd := fmt.Sprintf(
+			`sudo cp /etc/kubernetes/kubeadm-config.yaml /tmp/upload-certs-config.yaml && `+
+				`sudo sed -i '/^kind: InitConfiguration/a certificateKey: %s' /tmp/upload-certs-config.yaml`,
+			certificateKey)
+		if _, err := cpSSHClient.Exec(ctx, writeCmd); err != nil {
+			return "", fmt.Errorf("failed to write upload-certs config: %w", err)
+		}
+
+		if _, err := cpSSHClient.Exec(ctx, "sudo kubeadm init phase upload-certs --upload-certs --config /tmp/upload-certs-config.yaml"); err != nil {
 			return "", fmt.Errorf("failed to upload certificates: %w", err)
 		}
 

--- a/internal/cluster/kubeadm-config.yaml.tmpl
+++ b/internal/cluster/kubeadm-config.yaml.tmpl
@@ -8,6 +8,7 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
+kubernetesVersion: "{{.KubernetesVersion}}"
 controlPlaneEndpoint: "{{.AdvertiseAddress}}:6443"
 apiServer:
   certSANs:


### PR DESCRIPTION
The previous approach ran `kubeadm init phase upload-certs --upload-certs` and piped the output through `2>/dev/null | tail -1` to extract the certificate key. This broke because kubeadm prints informational `[upload-certs]` lines to stdout (not stderr), so `2>/dev/null` had no effect on them, and `tail -1` could grab a trailing empty line instead of the actual 64-char hex key.

Fix by generating the key separately with `kubeadm certs certificate-key` which outputs only the key, then passing it explicitly to `kubeadm init phase upload-certs --upload-certs --certificate-key <key>`.

## Summary by Sourcery

Bug Fixes:
- Resolve control-plane join failures caused by capturing an empty certificate key from kubeadm output by generating the key explicitly and reusing it for cert upload.