### PR TITLE
Use remote digest for BOOTC_DIGEST label

### DIFF
--- a/.github/workflows/build-node-image.yaml
+++ b/.github/workflows/build-node-image.yaml
@@ -44,10 +44,6 @@ jobs:
         working-directory: node-images/fedora
         run: make build-bootc-image
 
-      - name: Build disk image
-        working-directory: node-images/fedora
-        run: make build-disk-image
-
       - name: Determine image tag
         id: meta
         working-directory: node-images/fedora
@@ -56,22 +52,42 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Image tag: ${TAG}"
 
-      - name: Tag and push
+      - name: Push bootc image
+        id: push-bootc
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
         working-directory: node-images/fedora
         run: |
           TAG=${{ steps.meta.outputs.tag }}
           BOOTC_SRC=$(make -s print-bootc-image)
-          DISK_SRC=$(make -s print-node-image)
           PUSH_DEST=${{ env.PUSH_REGISTRY }}/${{ env.PUSH_IMAGE }}
 
-          # push bootc image under both :latest and versioned tags
           podman tag ${BOOTC_SRC} ${PUSH_DEST}:${TAG}
-          podman push ${PUSH_DEST}:${TAG}
+          podman push --digestfile=/tmp/bootc-digest ${PUSH_DEST}:${TAG}
           podman tag ${BOOTC_SRC} ${PUSH_DEST}:latest
           podman push ${PUSH_DEST}:latest
 
-          # push disk image under both :latest-disk and versioned tags
+          BOOTC_DIGEST=$(cat /tmp/bootc-digest)
+          echo "digest=${BOOTC_DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Bootc image pushed with digest: ${BOOTC_DIGEST}"
+
+      - name: Build disk image
+        working-directory: node-images/fedora
+        run: |
+          BOOTC_DIGEST="${{ steps.push-bootc.outputs.digest }}"
+          if [ -n "${BOOTC_DIGEST}" ]; then
+            make build-disk-image BOOTC_DIGEST="${BOOTC_DIGEST}"
+          else
+            make build-disk-image
+          fi
+
+      - name: Push disk image
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
+        working-directory: node-images/fedora
+        run: |
+          TAG=${{ steps.meta.outputs.tag }}
+          DISK_SRC=$(make -s print-node-image)
+          PUSH_DEST=${{ env.PUSH_REGISTRY }}/${{ env.PUSH_IMAGE }}
+
           podman tag ${DISK_SRC} ${PUSH_DEST}:${TAG}-disk
           podman push ${PUSH_DEST}:${TAG}-disk
           podman tag ${DISK_SRC} ${PUSH_DEST}:latest-disk

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -9,6 +9,7 @@ IMAGE_TAG ?= v$(KUBE_MINOR)-fedora-$(FEDORA_VERSION)
 REGISTRY ?= ghcr.io/alicefr/bink
 BOOTC_IMAGE ?= $(REGISTRY)/node:$(IMAGE_TAG)
 NODE_IMAGE ?= $(REGISTRY)/node:$(IMAGE_TAG)-disk
+BOOTC_DIGEST ?=
 
 # Build the OCI bootc image (k8s + cri-o)
 build-bootc-image:
@@ -27,7 +28,11 @@ build-bootc-image:
 build-disk-image: build-bootc-image
 	@echo "=== Building node image with qcow2 disk ==="
 	STORAGE_PATH=$$(podman info --format '{{.Store.GraphRoot}}') && \
-	BOOTC_DIGEST=$$(podman inspect --format '{{.Digest}}' $(BOOTC_IMAGE)) && \
+	if [ -z "$(BOOTC_DIGEST)" ]; then \
+		BOOTC_DIGEST=$$(podman inspect --format '{{.Digest}}' $(BOOTC_IMAGE)); \
+	else \
+		BOOTC_DIGEST="$(BOOTC_DIGEST)"; \
+	fi && \
 	podman build \
 		--cap-add=SYS_ADMIN \
 		--cap-add=DAC_READ_SEARCH \


### PR DESCRIPTION
Push the bootc image before building the disk image so that BOOTC_DIGEST reflects the registry digest after compression.

## Summary by Sourcery

Push the bootc image before building the disk image so the BOOTC_DIGEST label uses the registry-compressed digest.

Enhancements:
- Adjust Fedora node image workflow to push the bootc image first and export its registry digest for subsequent steps.
- Update disk image build to accept an optional BOOTC_DIGEST parameter and fall back to a local inspect when not provided.

CI:
- Split bootc and disk image push steps in the GitHub Actions workflow and wire digest output between them.