### PR TITLE
DNM CI: investigate tests KVM regression

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,12 @@ jobs:
             libgpgme-dev \
             libbtrfs-dev \
             libdevmapper-dev \
-            pkg-config
+            pkg-config \
+            systemd=255.4-1ubuntu8.15 \
+            libsystemd0=255.4-1ubuntu8.15 \
+            libsystemd-shared=255.4-1ubuntu8.15 \
+            libudev1=255.4-1ubuntu8.15 \
+            udev=255.4-1ubuntu8.15
 
       - name: Configure Podman
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,11 +29,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up KVM
-        run: |
-          sudo chmod 666 /dev/kvm
-          ls -la /dev/kvm
-
       - name: Configure kernel for nested containers
         run: |
           # Unload all AppArmor profiles from the kernel.
@@ -65,19 +60,13 @@ jobs:
             libgpgme-dev \
             libbtrfs-dev \
             libdevmapper-dev \
-            pkg-config \
-            systemd=255.4-1ubuntu8.15 \
-            systemd-dev=255.4-1ubuntu8.15 \
-            systemd-resolved=255.4-1ubuntu8.15 \
-            systemd-sysv=255.4-1ubuntu8.15 \
-            systemd-coredump=255.4-1ubuntu8.15 \
-            libsystemd0=255.4-1ubuntu8.15 \
-            libsystemd-shared=255.4-1ubuntu8.15 \
-            libudev1=255.4-1ubuntu8.15 \
-            libudev-dev=255.4-1ubuntu8.15 \
-            libnss-systemd=255.4-1ubuntu8.15 \
-            libpam-systemd=255.4-1ubuntu8.15 \
-            udev=255.4-1ubuntu8.15
+            pkg-config
+
+      - name: Set up KVM
+        run: |
+          # Re-apply after apt-get which may upgrade udev and reset device permissions
+          sudo chmod 666 /dev/kvm
+          ls -la /dev/kvm
 
       - name: Configure Podman
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,9 +67,16 @@ jobs:
             libdevmapper-dev \
             pkg-config \
             systemd=255.4-1ubuntu8.15 \
+            systemd-dev=255.4-1ubuntu8.15 \
+            systemd-resolved=255.4-1ubuntu8.15 \
+            systemd-sysv=255.4-1ubuntu8.15 \
+            systemd-coredump=255.4-1ubuntu8.15 \
             libsystemd0=255.4-1ubuntu8.15 \
             libsystemd-shared=255.4-1ubuntu8.15 \
             libudev1=255.4-1ubuntu8.15 \
+            libudev-dev=255.4-1ubuntu8.15 \
+            libnss-systemd=255.4-1ubuntu8.15 \
+            libpam-systemd=255.4-1ubuntu8.15 \
             udev=255.4-1ubuntu8.15
 
       - name: Configure Podman


### PR DESCRIPTION
The systemd 255.4-1ubuntu8.16 update from noble-updates breaks /dev/kvm passthrough into podman containers. 
CI:
- Update integration test GitHub Actions workflow to install systemd and related packages at version 255.4-1ubuntu8.15 for reproducible CI runs.