### PR TITLE
Fix control-plane join failing with empty certificate key

### DIFF
--- a/internal/cluster/join.go
+++ b/internal/cluster/join.go
@@ -152,7 +152,7 @@ func (c *Cluster) generateJoinCommand(ctx context.Context, cpSSHClient *ssh.Clie
 		// The command prints log lines to stderr and the 64-char hex key on stdout.
 		// We avoid piping (which masks the exit code) and extract the key ourselves.
 		c.logger.Info("Uploading certificates for control-plane join...")
-		certKeyOutput, err := cpSSHClient.Exec(ctx, "sudo kubeadm init phase upload-certs --upload-certs")
+		certKeyOutput, err := cpSSHClient.Exec(ctx, "sudo kubeadm init phase upload-certs --upload-certs --config /etc/kubernetes/kubeadm-config.yaml")
 		if err != nil {
 			return "", fmt.Errorf("failed to upload certificates: %w", err)
 		}

--- a/internal/cluster/join.go
+++ b/internal/cluster/join.go
@@ -132,19 +132,40 @@ func (c *Cluster) Join(ctx context.Context, opts JoinOptions) error {
 	return nil
 }
 
+func isHex(s string) bool {
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		case c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // generateJoinCommand generates a fresh join command from the control plane
 func (c *Cluster) generateJoinCommand(ctx context.Context, cpSSHClient *ssh.Client, isControlPlane bool) (string, error) {
 	if isControlPlane {
-		// For control-plane nodes, we need to upload certificates and get the certificate key
+		// For control-plane nodes, we need to upload certificates and get the certificate key.
+		// The command prints log lines to stderr and the 64-char hex key on stdout.
+		// We avoid piping (which masks the exit code) and extract the key ourselves.
 		c.logger.Info("Uploading certificates for control-plane join...")
-		certKeyOutput, err := cpSSHClient.Exec(ctx, "sudo kubeadm init phase upload-certs --upload-certs 2>/dev/null | tail -1")
+		certKeyOutput, err := cpSSHClient.Exec(ctx, "sudo kubeadm init phase upload-certs --upload-certs")
 		if err != nil {
 			return "", fmt.Errorf("failed to upload certificates: %w", err)
 		}
 
-		certificateKey := strings.TrimSpace(certKeyOutput)
+		var certificateKey string
+		for _, line := range strings.Split(certKeyOutput, "\n") {
+			line = strings.TrimSpace(line)
+			if len(line) == 64 && isHex(line) {
+				certificateKey = line
+			}
+		}
 		if certificateKey == "" {
-			return "", fmt.Errorf("certificate key is empty")
+			return "", fmt.Errorf("certificate key not found in upload-certs output: %s", certKeyOutput)
 		}
 
 		c.logger.Infof("Certificate key: %s", certificateKey)


### PR DESCRIPTION
The upload-certs command was piped through `2>/dev/null | tail -1`, which suppressed errors and masked the exit code. When kubeadm failed, we got an empty string instead of an error.

Remove the pipe and stderr suppression so failures propagate properly. Extract the certificate key by matching the 64-char hex string from the output instead of blindly taking the last line.

## Summary by Sourcery

Ensure control-plane join correctly obtains the kubeadm certificate key by using the full upload-certs output and parsing the hex key instead of relying on a piped tail command.

Bug Fixes:
- Fix control-plane joins failing due to empty certificate keys when kubeadm upload-certs reports an error that was previously suppressed.

Enhancements:
- Improve robustness of certificate key extraction by scanning upload-certs output for a 64-character hexadecimal key and surfacing detailed errors when not found.