### PR TITLE
Fix digest show by bootc status and the one reported on the disk image

### DIFF
--- a/.github/workflows/build-node-image.yaml
+++ b/.github/workflows/build-node-image.yaml
@@ -69,13 +69,18 @@ jobs:
           BOOTC_DIGEST=$(cat /tmp/bootc-digest)
           echo "digest=${BOOTC_DIGEST}" >> "$GITHUB_OUTPUT"
           echo "Bootc image pushed with digest: ${BOOTC_DIGEST}"
+          echo "Clean up local images"
+          podman rmi -f ${BOOTC_SRC} ${PUSH_DEST}:${TAG} ${PUSH_DEST}:latest
+          echo "push_dest=${PUSH_DEST}:${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build disk image
         working-directory: node-images/fedora
         run: |
           BOOTC_DIGEST="${{ steps.push-bootc.outputs.digest }}"
-          if [ -n "${BOOTC_DIGEST}" ]; then
-            make build-disk-image BOOTC_DIGEST="${BOOTC_DIGEST}"
+          PUSH_DEST="${{ steps.push-bootc.outputs.push_dest }}"
+          if [ -n "${BOOTC_DIGEST}" ] && [ -n "${PUSH_DEST}" ]; then
+            podman pull "${PUSH_DEST}"
+            make build-disk-image BOOTC_IMAGE="${PUSH_DEST}" BOOTC_DIGEST="${BOOTC_DIGEST}"
           else
             make build-disk-image
           fi

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -25,7 +25,7 @@ build-bootc-image:
 	@echo "✅ Bootc image built: $(BOOTC_IMAGE)"
 
 # Build the disk image (qcow2 in a scratch container, for use as a podman image volume)
-build-disk-image: build-bootc-image
+build-disk-image:
 	@echo "=== Building node image with qcow2 disk ==="
 	STORAGE_PATH=$$(podman info --format '{{.Store.GraphRoot}}') && \
 	if [ -z "$(BOOTC_DIGEST)" ]; then \


### PR DESCRIPTION
The digest reported on the disk image still doesn't match with digested reported by bootc status once boooted. This PR ensure that there are no local images left and the base image is freshly pulled from the registry