### PR TITLE
Disable DHCP-provided DNS on VM passt NIC

### DIFF
--- a/internal/node/templates/user-data.yaml.tmpl
+++ b/internal/node/templates/user-data.yaml.tmpl
@@ -81,7 +81,7 @@ runcmd:
   - systemctl enable --now var-mnt-cluster_images.mount
   - systemctl enable --now ostree-state-overlay@opt.service
   - systemctl enable --now qemu-guest-agent
-  - nmcli connection modify "cloud-init enp2s0" ipv4.dns-search "~{{.ClusterDomain}} {{.ClusterDomain}}"
+  - nmcli connection modify "cloud-init enp2s0" ipv4.dns-search "~{{.ClusterDomain}} {{.ClusterDomain}}" ipv4.ignore-auto-dns yes
   - nmcli connection up "cloud-init enp2s0"
   - systemctl enable --now crio
   - systemctl enable kubelet


### PR DESCRIPTION
passt injects additional DNS servers (169.254.1.1, host gateway) via DHCP that don't know about cluster.local. systemd-resolved may query these before the bink DNS container and accept an NXDOMAIN, causing flaky registry.cluster.local resolution on worker nodes.

Setting ipv4.ignore-auto-dns prevents DHCP DNS from being added to the link, leaving only the bink DNS container which forwards non-cluster queries to upstream (8.8.8.8, 8.8.4.4).

Fixes: https://github.com/alicefr/bink/issues/59

## Summary by Sourcery

Bug Fixes:
- Prevent flaky resolution of cluster-local domains by ignoring auto-provisioned DNS from DHCP on the worker node network interface.