### PR TITLE
Add composefs backend

### DIFF
--- a/.github/workflows/build-node-image.yaml
+++ b/.github/workflows/build-node-image.yaml
@@ -97,3 +97,27 @@ jobs:
           podman push ${PUSH_DEST}:${TAG}-disk
           podman tag ${DISK_SRC} ${PUSH_DEST}:latest-disk
           podman push ${PUSH_DEST}:latest-disk
+
+      - name: Build composefs disk image
+        working-directory: node-images/fedora
+        run: |
+          BOOTC_DIGEST="${{ steps.push-bootc.outputs.digest }}"
+          PUSH_DEST="${{ steps.push-bootc.outputs.push_dest }}"
+          if [ -n "${BOOTC_DIGEST}" ] && [ -n "${PUSH_DEST}" ]; then
+            make build-disk-image-composefs BOOTC_IMAGE="${PUSH_DEST}" BOOTC_DIGEST="${BOOTC_DIGEST}"
+          else
+            make build-disk-image-composefs
+          fi
+
+      - name: Push composefs disk image
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
+        working-directory: node-images/fedora
+        run: |
+          TAG=${{ steps.meta.outputs.tag }}
+          DISK_SRC=$(make -s print-node-image-composefs)
+          PUSH_DEST=${{ env.PUSH_REGISTRY }}/${{ env.PUSH_IMAGE }}
+
+          podman tag ${DISK_SRC} ${PUSH_DEST}:${TAG}-disk-composefs
+          podman push ${PUSH_DEST}:${TAG}-disk-composefs
+          podman tag ${DISK_SRC} ${PUSH_DEST}:latest-disk-composefs
+          podman push ${PUSH_DEST}:latest-disk-composefs

--- a/internal/cluster/calico.yaml
+++ b/internal/cluster/calico.yaml
@@ -5026,7 +5026,7 @@ spec:
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
-            path: /opt/cni/bin
+            path: /var/lib/cni/bin
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d

--- a/internal/cluster/init.go
+++ b/internal/cluster/init.go
@@ -119,7 +119,7 @@ func (c *Cluster) Init(ctx context.Context, opts InitOptions) error {
 		return fmt.Errorf("failed to install Calico: %w", err)
 	}
 
-	c.logger.Info("CNI plugins will be installed to /opt/cni/bin (tmpfs overlay for bootc)")
+	c.logger.Info("CNI plugins will be installed to /var/lib/cni/bin")
 
 	// Wait for Calico to write its CNI config before installing CoreDNS
 	c.logger.Info("Waiting for Calico CNI configuration...")

--- a/internal/node/templates/user-data.yaml.tmpl
+++ b/internal/node/templates/user-data.yaml.tmpl
@@ -32,7 +32,6 @@ write_files:
     content: |
       [crio.network]
       plugin_dirs = [
-        "/opt/cni/bin",
         "/var/lib/cni/bin",
         "/usr/libexec/cni",
       ]
@@ -75,11 +74,12 @@ runcmd:
   - sysctl -w net.ipv4.ip_forward=1
   - echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/99-kubernetes.conf
   - mkdir -p /var/lib/kubelet/volumeplugins
+  - mkdir -p /var/lib/cni/bin
   - mkdir -p /var/mnt/cluster_images
   - mkdir -p /var/lib/containers/storage
   - systemctl daemon-reload
   - systemctl enable --now var-mnt-cluster_images.mount
-  - systemctl enable --now ostree-state-overlay@opt.service
+  - systemctl enable --now ostree-state-overlay@opt.service || true
   - systemctl enable --now qemu-guest-agent
   - nmcli connection modify "cloud-init enp2s0" ipv4.dns-search "~{{.ClusterDomain}} {{.ClusterDomain}}"
   - nmcli connection up "cloud-init enp2s0"

--- a/node-images/fedora/Containerfile
+++ b/node-images/fedora/Containerfile
@@ -34,7 +34,8 @@ FROM scratch AS root
 COPY --from=builder /target-rootfs/ /
 
 RUN passwd -d root
-RUN sed -i 's|"/opt/cni/bin"|"/var/lib/cni/bin"|g' /etc/crio/crio.conf
+RUN sed -i 's|"/opt/cni/bin"|"/var/lib/cni/bin"|g' /etc/crio/crio.conf && \
+    sed -i 's|"/opt/cni/net.d"|"/etc/cni/net.d"|g' /etc/crio/crio.conf
 RUN bootc container lint
 
 LABEL containers.bootc 1

--- a/node-images/fedora/Containerfile.disk
+++ b/node-images/fedora/Containerfile.disk
@@ -9,6 +9,7 @@ ARG STORAGE_PATH
 ARG BOOTC_IMAGE
 ARG DISK_SIZE=10G
 ARG MEMORY=4G
+ARG BCVK_EXTRA_ARGS=""
 ENV CONTAINERS_STORAGE_CONF=/tmp/storage.conf
 RUN mkdir -p /output && \
     printf "[storage]\ndriver = \"overlay\"\ngraphroot = \"${STORAGE_PATH}\"\n" > $CONTAINERS_STORAGE_CONF && \
@@ -19,6 +20,7 @@ RUN mkdir -p /output && \
     --format qcow2 \
     --memory ${MEMORY} \
     --disk-size ${DISK_SIZE} \
+    ${BCVK_EXTRA_ARGS} \
     ${BOOTC_IMAGE} \
     /output/disk.qcow2
 RUN podman run --rm ${BOOTC_IMAGE} kubeadm config images list > /output/images.txt

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -1,14 +1,16 @@
-.PHONY: build-bootc-image build-disk-image clean help
+.PHONY: build-bootc-image build-disk-image build-disk-image-composefs clean help
 
 KUBE_MINOR ?= 1.35
 FEDORA_VERSION ?= 44
 DISK_SIZE ?= 10G
 BUILD_MEMORY ?= 4G
+BCVK_EXTRA_ARGS ?=
 
 IMAGE_TAG ?= v$(KUBE_MINOR)-fedora-$(FEDORA_VERSION)
 REGISTRY ?= ghcr.io/alicefr/bink
 BOOTC_IMAGE ?= $(REGISTRY)/node:$(IMAGE_TAG)
 NODE_IMAGE ?= $(REGISTRY)/node:$(IMAGE_TAG)-disk
+NODE_IMAGE_COMPOSEFS ?= $(REGISTRY)/node:$(IMAGE_TAG)-disk-composefs
 BOOTC_DIGEST ?=
 
 # Build the OCI bootc image (k8s + cri-o)
@@ -47,12 +49,16 @@ build-disk-image:
 		--build-arg MEMORY="$(BUILD_MEMORY)" \
 		--build-arg KUBE_MINOR="$(KUBE_MINOR)" \
 		--build-arg BOOTC_DIGEST="$$BOOTC_DIGEST" \
+		--build-arg BCVK_EXTRA_ARGS="$(BCVK_EXTRA_ARGS)" \
 		-t $(NODE_IMAGE) \
 		-f Containerfile.disk \
 		.
 	@echo "✅ Node image built: $(NODE_IMAGE)"
 	@echo ""
 	@echo "This image can be used with: bink cluster start --node-image $(NODE_IMAGE)"
+
+build-disk-image-composefs:
+	$(MAKE) build-disk-image BCVK_EXTRA_ARGS="--composefs-backend" NODE_IMAGE="$(NODE_IMAGE_COMPOSEFS)"
 
 print-image-tag:
 	@echo $(IMAGE_TAG)
@@ -63,6 +69,9 @@ print-bootc-image:
 print-node-image:
 	@echo $(NODE_IMAGE)
 
+print-node-image-composefs:
+	@echo $(NODE_IMAGE_COMPOSEFS)
+
 clean:
 	@echo "=== Cleaning up ==="
 	podman rmi -f $(BOOTC_IMAGE) $(NODE_IMAGE) 2>/dev/null || true
@@ -72,9 +81,10 @@ help:
 	@echo "Makefile for building bink node images (Fedora)"
 	@echo ""
 	@echo "Targets:"
-	@echo "  build-bootc-image - Build the OCI bootc image"
-	@echo "  build-disk-image  - Build the OCI disk image with qcow2 (default)"
-	@echo "  clean             - Remove built images"
+	@echo "  build-bootc-image          - Build the OCI bootc image"
+	@echo "  build-disk-image           - Build the OCI disk image with qcow2 (default, ostree backend)"
+	@echo "  build-disk-image-composefs - Build the OCI disk image with composefs backend"
+	@echo "  clean                      - Remove built images"
 	@echo ""
 	@echo "Variables:"
 	@echo "  BOOTC_IMAGE      - Bootc OCI image name (default: $(BOOTC_IMAGE))"
@@ -83,3 +93,4 @@ help:
 	@echo "  FEDORA_VERSION   - Fedora version (default: $(FEDORA_VERSION))"
 	@echo "  DISK_SIZE        - VM disk size (default: $(DISK_SIZE))"
 	@echo "  BUILD_MEMORY     - Memory for bcvk build (default: $(BUILD_MEMORY))"
+	@echo "  BCVK_EXTRA_ARGS  - Extra arguments passed to bcvk to-disk (default: none)"


### PR DESCRIPTION
Fixes: #9

## Summary by Sourcery

Add support for building and publishing Fedora node disk images using a composefs backend and align CNI paths with /var/lib/cni/bin across the system.

New Features:
- Introduce a composefs-backed node disk image variant and associated Make targets.
- Extend the CI workflow to build and push composefs disk images for Fedora node images.

Enhancements:
- Align CRI-O and Calico configuration to use /var/lib/cni/bin and /etc/cni/net.d for CNI plugins and configs.
- Make the ostree-state-overlay@opt service enabling step tolerant of failure during node initialization.
- Document new Makefile targets and BCVK extra arguments in the Fedora node image build help output.

CI:
- Update the node image build GitHub Actions workflow to build and push composefs disk image variants.