### PR TITLE
Makefile: auto-detect btrfs headers for portable local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ LDFLAGS := -X $(VERSION_PKG).Version=$(VERSION) \
            -X $(VERSION_PKG).GitCommit=$(GIT_COMMIT) \
            -X $(VERSION_PKG).BuildDate=$(BUILD_DATE)
 
+# Build tags (auto-detect optional C dependencies)
+BUILDTAGS ?= \
+	$(shell hack/btrfs_installed_tag.sh)
+
 # Directories
 VM_DIR := containerfiles/cluster-image
 
@@ -29,7 +33,7 @@ all: build-bink
 # Build the bink CLI binary
 build-bink:
 	@echo "=== Building bink CLI binary ==="
-	go build -ldflags "$(LDFLAGS)" -o $(BINK_BINARY) ./cmd/bink
+	go build -tags "$(BUILDTAGS)" -ldflags "$(LDFLAGS)" -o $(BINK_BINARY) ./cmd/bink
 	@echo "✅ bink binary built: $(BINK_BINARY)"
 
 

--- a/hack/btrfs_installed_tag.sh
+++ b/hack/btrfs_installed_tag.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+${CPP:-${CC:-cc} -E} ${CPPFLAGS} - > /dev/null 2> /dev/null << EOF
+#include <btrfs/ioctl.h>
+EOF
+if test $? -ne 0; then
+    echo exclude_graphdriver_btrfs
+fi


### PR DESCRIPTION
- make build-bink fails on systems without btrfs-progs-devel
- Add hack/btrfs_installed_tag.sh — probes for btrfs/ioctl.h and emits exclude_graphdriver_btrfs when headers are absent (same pattern used by Podman, Buildah, and Skopeo)
- On systems with btrfs-progs-devel installed, behavior is unchanged — btrfs compiles normally
```
harshpat@harshpat-thinkpadp1gen4i:~/Downloads/repos/bink$ make build-bink
=== Building bink CLI binary ===
go build -ldflags "-X github.com/bootc-dev/bink/internal/version.Version=dev -X github.com/bootc-dev/bink/internal/version.GitCommit=d30220c -X github.com/bootc-dev/bink/internal/version.BuildDate=2026-06-22T11:30:14Z" -o bink ./cmd/bink
# github.com/containers/storage/drivers/btrfs
../../../coderepo/pkg/mod/github.com/containers/storage@v1.58.0/drivers/btrfs/version.go:6:10: fatal error: btrfs/version.h: No such file or directory
    6 | #include <btrfs/version.h>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:32: build-bink] Error 1
```