### PR TITLE
Move repository references from alicefr/bink to bootc-dev/bink

### DIFF
--- a/.github/workflows/build-node-image.yaml
+++ b/.github/workflows/build-node-image.yaml
@@ -17,7 +17,7 @@ on:
         type: boolean
 
 env:
-  PUSH_REGISTRY: ghcr.io/alicefr/bink
+  PUSH_REGISTRY: ghcr.io/bootc-dev/bink
   PUSH_IMAGE: node
 
 jobs:

--- a/node-images/fedora/Containerfile
+++ b/node-images/fedora/Containerfile
@@ -2,7 +2,7 @@ FROM quay.io/fedora/fedora-bootc:44 AS builder
 
 ARG KUBE_MINOR=1.35
 # Pin kernel to 6.19.x to work around a kernel 7.0 regression.
-# https://github.com/alicefr/bink/issues/52
+# https://github.com/bootc-dev/bink/issues/52
 ARG KERNEL_VERSION=6.19.14-300.fc44
 RUN /usr/libexec/bootc-base-imagectl build-rootfs \
     --manifest=minimal \

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -7,7 +7,7 @@ BUILD_MEMORY ?= 4G
 BCVK_EXTRA_ARGS ?=
 
 IMAGE_TAG ?= v$(KUBE_MINOR)-fedora-$(FEDORA_VERSION)
-REGISTRY ?= ghcr.io/alicefr/bink
+REGISTRY ?= ghcr.io/bootc-dev/bink
 BOOTC_IMAGE ?= $(REGISTRY)/node:$(IMAGE_TAG)
 NODE_IMAGE ?= $(REGISTRY)/node:$(IMAGE_TAG)-disk
 NODE_IMAGE_COMPOSEFS ?= $(REGISTRY)/node:$(IMAGE_TAG)-disk-composefs


### PR DESCRIPTION
Since we moved the bink repository from my account the bootc-dev org, we need to update the references for the old location.