### PR TITLE
Update container image references from alicefr to bootc-dev

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,9 +12,9 @@ concurrency:
 
 env:
   BINK_IMAGES: >-
-    ghcr.io/alicefr/bink/cluster:latest
-    ghcr.io/alicefr/bink/node:v1.35-fedora-44-disk
-    ghcr.io/alicefr/bink/dns:latest
+    ghcr.io/bootc-dev/bink/cluster:latest
+    ghcr.io/bootc-dev/bink/node:v1.35-fedora-44-disk
+    ghcr.io/bootc-dev/bink/dns:latest
   EXTERNAL_IMAGES: >-
     docker.io/library/registry:2
     docker.io/library/haproxy:lts-alpine

--- a/.github/workflows/test-container-image.yml
+++ b/.github/workflows/test-container-image.yml
@@ -17,9 +17,9 @@ concurrency:
 
 env:
   BINK_RUNTIME_IMAGES: >-
-    ghcr.io/alicefr/bink/cluster:latest
-    ghcr.io/alicefr/bink/node:v1.35-fedora-44-disk
-    ghcr.io/alicefr/bink/dns:latest
+    ghcr.io/bootc-dev/bink/cluster:latest
+    ghcr.io/bootc-dev/bink/node:v1.35-fedora-44-disk
+    ghcr.io/bootc-dev/bink/dns:latest
 
 jobs:
   test-container-image:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ podman run --rm -ti --network=host --security-opt label=disable \
   -v $XDG_RUNTIME_DIR/podman/podman.sock:/run/podman/podman.sock \
   -e CONTAINER_HOST=unix:///run/podman/podman.sock \
   -v $(pwd):/output \
-  ghcr.io/alicefr/bink/bink:latest \
+  ghcr.io/bootc-dev/bink/bink:latest \
   cluster start
 
 # Expose the API (kubeconfig is written to the mounted directory)
@@ -42,7 +42,7 @@ podman run --rm -ti --network=host --security-opt label=disable \
   -v $XDG_RUNTIME_DIR/podman/podman.sock:/run/podman/podman.sock \
   -e CONTAINER_HOST=unix:///run/podman/podman.sock \
   -v $(pwd):/output \
-  ghcr.io/alicefr/bink/bink:latest \
+  ghcr.io/bootc-dev/bink/bink:latest \
   api expose
 ```
 
@@ -52,7 +52,7 @@ alias bink='podman run --rm -ti --network=host --security-opt label=disable \
   -v $XDG_RUNTIME_DIR/podman/podman.sock:/run/podman/podman.sock \
   -e CONTAINER_HOST=unix:///run/podman/podman.sock \
   -v $(pwd):/output \
-  ghcr.io/alicefr/bink/bink:latest'
+  ghcr.io/bootc-dev/bink/bink:latest'
 ```
 
 Then use it like the native binary: `bink cluster start`, `bink api expose`, etc.
@@ -67,7 +67,7 @@ podman run -d --name bink --privileged \
   --device /dev/kvm \
   -v bink-storage:/var/lib/containers \
   -v $(pwd):/output \
-  ghcr.io/alicefr/bink/bink:latest
+  ghcr.io/bootc-dev/bink/bink:latest
 
 # Wait for podman service to be ready inside the container
 until podman exec bink podman info &>/dev/null; do sleep 0.5; done

--- a/hack/test-container-image.sh
+++ b/hack/test-container-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-BINK_IMAGE="${BINK_IMAGE:-ghcr.io/alicefr/bink/bink:latest}"
+BINK_IMAGE="${BINK_IMAGE:-ghcr.io/bootc-dev/bink/bink:latest}"
 IMAGE_CACHE_DIR="${IMAGE_CACHE_DIR:-}"
 if [ -n "${CONTAINER_HOST:-}" ]; then
     PODMAN_SOCK="${CONTAINER_HOST#unix://}"

--- a/internal/cluster/images_test.go
+++ b/internal/cluster/images_test.go
@@ -18,8 +18,8 @@ func TestExtractVersionFromTag(t *testing.T) {
 		imageRef string
 		expected string
 	}{
-		{"standard tag", "ghcr.io/alicefr/bink/node:v1.35-fedora-43-disk", "1.35"},
-		{"no v prefix", "ghcr.io/alicefr/bink/node:1.35-fedora-43", "1.35"},
+		{"standard tag", "ghcr.io/bootc-dev/bink/node:v1.35-fedora-43-disk", "1.35"},
+		{"no v prefix", "ghcr.io/bootc-dev/bink/node:1.35-fedora-43", "1.35"},
 		{"version only", "registry/repo:v1.30", "1.30"},
 		{"latest tag", "registry/repo:latest", ""},
 		{"no tag", "registry/repo", ""},
@@ -122,7 +122,7 @@ func TestGetKubeadmVersionFromImage(t *testing.T) {
 		mock := &mockPodmanClient{
 			imageLabels: map[string]string{"bink.kubeadm-version": "1.35"},
 		}
-		v, err := GetKubeadmVersionFromImage(ctx, mock, "ghcr.io/alicefr/bink/node:v1.35-fedora-43")
+		v, err := GetKubeadmVersionFromImage(ctx, mock, "ghcr.io/bootc-dev/bink/node:v1.35-fedora-43")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -135,7 +135,7 @@ func TestGetKubeadmVersionFromImage(t *testing.T) {
 		mock := &mockPodmanClient{
 			imageInspectErr: fmt.Errorf("image not known"),
 		}
-		v, err := GetKubeadmVersionFromImage(ctx, mock, "ghcr.io/alicefr/bink/node:v1.30-fedora-43")
+		v, err := GetKubeadmVersionFromImage(ctx, mock, "ghcr.io/bootc-dev/bink/node:v1.30-fedora-43")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -199,7 +199,7 @@ func TestGetKubeadmVersionFromImage(t *testing.T) {
 
 func TestEnsureImagesVolume(t *testing.T) {
 	ctx := context.Background()
-	nodeImage := "ghcr.io/alicefr/bink/node:v1.35-fedora-43"
+	nodeImage := "ghcr.io/bootc-dev/bink/node:v1.35-fedora-43"
 
 	t.Run("volume exists and completed", func(t *testing.T) {
 		mock := &mockPodmanClient{

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -15,11 +15,11 @@ const (
 
 	FedoraVersion = "43"
 
-	binkImageBase    = "ghcr.io/alicefr/bink/bink"
-	clusterImageBase = "ghcr.io/alicefr/bink/cluster"
-	dnsImageBase     = "ghcr.io/alicefr/bink/dns"
+	binkImageBase    = "ghcr.io/bootc-dev/bink/bink"
+	clusterImageBase = "ghcr.io/bootc-dev/bink/cluster"
+	dnsImageBase     = "ghcr.io/bootc-dev/bink/dns"
 
-	DefaultNodeImage = "ghcr.io/alicefr/bink/node:v1.35-fedora-44-disk"
+	DefaultNodeImage = "ghcr.io/bootc-dev/bink/node:v1.35-fedora-44-disk"
 
 	DefaultBaseDisk = "/images/disk.qcow2"
 	DefaultControlPlaneMemory    = 1900


### PR DESCRIPTION
Replace alicefr repository with the bootc-dev

We need to force merge this PR because the image names are used for building the images for the GHA and as defaults for bink. For this PR, the integration tests will fail