### PR TITLE
node-images: enable copr repo

### DIFF
--- a/node-images/fedora/Containerfile
+++ b/node-images/fedora/Containerfile
@@ -4,6 +4,8 @@ ARG KUBE_MINOR=1.35
 # Pin kernel to 6.19.x to work around a kernel 7.0 regression.
 # https://github.com/bootc-dev/bink/issues/52
 ARG KERNEL_VERSION=6.19.14-300.fc44
+RUN dnf -y install 'dnf5-command(copr)' && \
+    dnf -y copr enable rhcontainerbot/bootc fedora-44-x86_64
 RUN /usr/libexec/bootc-base-imagectl build-rootfs \
     --manifest=minimal \
     --no-docs \


### PR DESCRIPTION
Enable the copr repo before building the rootfs so that the composefs imageDigest fix from bootc-dev/bootc#2277 gets picked up once it merges and copr builds resume.