### PR TITLE
A minor cleanup and consolidation of the fedora version

### DIFF
--- a/.github/workflows/build-node-image.yaml
+++ b/.github/workflows/build-node-image.yaml
@@ -4,16 +4,16 @@ on:
   push:
     branches: [main]
     paths:
-      - 'node-images/fedora/**'
+      - "node-images/fedora/**"
   pull_request:
     paths:
-      - 'node-images/fedora/**'
+      - "node-images/fedora/**"
   workflow_dispatch:
     inputs:
       push:
-        description: 'Push image to registry'
+        description: "Push image to registry"
         required: false
-        default: 'false'
+        default: "false"
         type: boolean
 
 env:
@@ -44,7 +44,7 @@ jobs:
       contents: read
       packages: write
     container:
-      image: quay.io/fedora/fedora:43
+      image: quay.io/fedora/fedora:44
       options: --privileged --device /dev/kvm -v /var/lib/containers
     steps:
       - name: Install dependencies

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build environment for bink CLI with all C dependencies
-ARG FEDORA_VERSION=43
+ARG FEDORA_VERSION=44
 FROM quay.io/fedora/fedora:${FEDORA_VERSION} AS builder
 
 # Install Go and required C libraries for Podman bindings

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ extract = $(shell grep '$(1)' $(DEFAULTS_GO) | head -1 | sed 's/.*"\(.*\)"/\1/')
 BINK_IMAGE := $(call extract,binkImageBase ):latest
 CLUSTER_IMAGE := $(call extract,clusterImageBase ):latest
 DNS_IMAGE := $(call extract,dnsImageBase ):latest
-FEDORA_VERSION := $(call extract,FedoraVersion )
 
 # Binary
 BINK_BINARY := bink
@@ -40,13 +39,13 @@ build-bink:
 # Build the bink CLI container image
 build-bink-image:
 	@echo "=== Building bink CLI container image ==="
-	podman build --build-arg FEDORA_VERSION=$(FEDORA_VERSION) --build-arg VERSION=$(VERSION) -t $(BINK_IMAGE) -f Containerfile .
+	podman build --build-arg VERSION=$(VERSION) -t $(BINK_IMAGE) -f Containerfile .
 	@echo "✅ Bink CLI image built: $(BINK_IMAGE)"
 
 # Build the cluster container image
 build-cluster-image:
 	@echo "=== Building cluster container image ==="
-	podman build --build-arg FEDORA_VERSION=$(FEDORA_VERSION) -t $(CLUSTER_IMAGE) -f $(VM_DIR)/Containerfile $(VM_DIR)
+	podman build -t $(CLUSTER_IMAGE) -f $(VM_DIR)/Containerfile $(VM_DIR)
 	@echo "✅ Cluster image built: $(CLUSTER_IMAGE)"
 
 # Build the DNS container image

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,6 @@ build-bink:
 # Build the bink CLI container image
 build-bink-image:
 	@echo "=== Building bink CLI container image ==="
-	podman build --build-arg FEDORA_VERSION=$(FEDORA_VERSION) --build-arg VERSION=$(VERSION) --target builder -t localhost/bink-builder:latest -f Containerfile .
 	podman build --build-arg FEDORA_VERSION=$(FEDORA_VERSION) --build-arg VERSION=$(VERSION) -t $(BINK_IMAGE) -f Containerfile .
 	@echo "✅ Bink CLI image built: $(BINK_IMAGE)"
 

--- a/containerfiles/cluster-image/Containerfile
+++ b/containerfiles/cluster-image/Containerfile
@@ -1,4 +1,4 @@
-ARG FEDORA_VERSION=43
+ARG FEDORA_VERSION=44
 FROM quay.io/fedora/fedora:${FEDORA_VERSION}
 
 RUN dnf install -y --setopt=install_weak_deps=0 \

--- a/containerfiles/dns/Containerfile
+++ b/containerfiles/dns/Containerfile
@@ -1,4 +1,5 @@
-FROM registry.fedoraproject.org/fedora-minimal
+ARG FEDORA_VERSION=44
+FROM registry.fedoraproject.org/fedora-minimal:${FEDORA_VERSION}
 
 RUN microdnf install -y dnsmasq && microdnf clean all
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -13,21 +13,19 @@ const (
 	DefaultNetworkName = "podman"
 	DefaultSubnet      = "10.88.0.0/16"
 
-	FedoraVersion = "43"
-
 	binkImageBase    = "ghcr.io/bootc-dev/bink/bink"
 	clusterImageBase = "ghcr.io/bootc-dev/bink/cluster"
 	dnsImageBase     = "ghcr.io/bootc-dev/bink/dns"
 
 	DefaultNodeImage = "ghcr.io/bootc-dev/bink/node:v1.35-fedora-44-disk"
 
-	DefaultBaseDisk = "/images/disk.qcow2"
+	DefaultBaseDisk              = "/images/disk.qcow2"
 	DefaultControlPlaneMemory    = 1900
 	DefaultControlPlaneMaxMemory = 4096
 	DefaultWorkerMemory          = 768
 	DefaultWorkerMaxMemory       = 2048
 	DefaultVCPUs                 = 2
-	DefaultDiskSize = "10G"
+	DefaultDiskSize              = "10G"
 
 	DefaultSSHPort      = 2222
 	DefaultSSHUser      = "core"


### PR DESCRIPTION
This PR simplify the versioning for the image. This should also fix the update of the dependecies https://github.com/bootc-dev/bink/pull/84 since it is bumping the go version which wasn't included in fedora 43 but it is in 44.