### PR TITLE
Add synced files to reuse

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -73,3 +73,9 @@ path = "renovate.json"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 The bink Authors"
 SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [".bootc-dev-infra-commit.txt", "gemini/**"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 The bink Authors"
+SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
Right now those files don't exist in the tree but they are added by https://github.com/bootc-dev/bink/pull/86 and the reuse check if failing for this PR. This change allow the check to pass and that PR to be merged.