### PR TITLE
Fix the build for node images

### DIFF
--- a/.github/collect-logs.sh
+++ b/.github/collect-logs.sh
@@ -31,5 +31,12 @@ df -h | sudo tee "$LOG_DIR/disk.txt" > /dev/null || true
 free -h | sudo tee "$LOG_DIR/memory.txt" > /dev/null || true
 sudo dmesg | tail -100 | sudo tee "$LOG_DIR/host-dmesg.txt" > /dev/null || true
 
+for bcvk_dir in /tmp/bcvk-logs*; do
+  [ -d "$bcvk_dir" ] || continue
+  dest="$LOG_DIR/$(basename "$bcvk_dir")"
+  mkdir -p "$dest"
+  cp -r "$bcvk_dir"/. "$dest"/ 2>/dev/null || true
+done
+
 echo "Logs collected in $LOG_DIR"
 ls -R "$LOG_DIR"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -139,6 +139,17 @@ jobs:
           name: node-image-composefs-${{ matrix.kube-minor }}
           path: node-image-composefs.tar
 
+      - name: Collect logs
+        if: failure()
+        run: .github/collect-logs.sh
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-logs-${{ matrix.kube-minor }}
+          path: /tmp/bink-logs/
+
   integration-tests:
     needs: [changes, supported-versions, build-node-images]
     # Run when build-node-images is skipped (no node image changes) or succeeded, but not when it failed

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -83,6 +83,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up KVM
+        run: |
+          sudo chmod 666 /dev/kvm
+          ls -la /dev/kvm
+
       - name: Build bootc image
         working-directory: node-images/fedora
         run: sudo make build-bootc-image KUBE_MINOR=${{ matrix.kube-minor }}

--- a/node-images/fedora/Containerfile.disk
+++ b/node-images/fedora/Containerfile.disk
@@ -9,9 +9,11 @@ ARG STORAGE_PATH
 ARG BOOTC_IMAGE
 ARG DISK_SIZE=10G
 ARG MEMORY=4G
+ARG LOG_DIR=/tmp/bcvk-logs
 ARG BCVK_EXTRA_ARGS=""
 ENV CONTAINERS_STORAGE_CONF=/tmp/storage.conf
-RUN mkdir -p /output && \
+ENV RUST_LOG=debug
+RUN mkdir -p /output ${LOG_DIR} && \
     printf "[storage]\ndriver = \"overlay\"\ngraphroot = \"${STORAGE_PATH}\"\n" > $CONTAINERS_STORAGE_CONF && \
     bcvk to-disk -K \
     --karg 'console=tty0' \
@@ -20,6 +22,7 @@ RUN mkdir -p /output && \
     --format qcow2 \
     --memory ${MEMORY} \
     --disk-size ${DISK_SIZE} \
+    --log-dir journal,console=${LOG_DIR} \
     ${BCVK_EXTRA_ARGS} \
     ${BOOTC_IMAGE} \
     /output/disk.qcow2

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -46,6 +46,7 @@ build-disk-image:
 		--cap-add=DAC_READ_SEARCH \
 		--cap-add=MKNOD \
 		--security-opt=label=disable \
+		--ulimit nofile=65536:65536 \
 		--device=/dev/kvm \
 		--volume "$$STORAGE_PATH:$$STORAGE_PATH" \
 		$$LOG_VOLUME \

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -4,6 +4,7 @@ KUBE_MINOR ?= 1.35
 FEDORA_VERSION ?= 44
 DISK_SIZE ?= 10G
 BUILD_MEMORY ?= 4G
+BUILD_LOG_DIR ?= /tmp/bcvk-logs
 BCVK_EXTRA_ARGS ?=
 
 IMAGE_TAG ?= v$(KUBE_MINOR)-fedora-$(FEDORA_VERSION)
@@ -35,6 +36,11 @@ build-disk-image:
 	else \
 		BOOTC_DIGEST="$(BOOTC_DIGEST)"; \
 	fi && \
+	LOG_VOLUME="" && \
+	if [ -n "$(BUILD_LOG_DIR)" ]; then \
+		mkdir -p "$(BUILD_LOG_DIR)"; \
+		LOG_VOLUME="--volume $(BUILD_LOG_DIR):$(BUILD_LOG_DIR) --build-arg LOG_DIR=$(BUILD_LOG_DIR)"; \
+	fi && \
 	podman build \
 		--cap-add=SYS_ADMIN \
 		--cap-add=DAC_READ_SEARCH \
@@ -42,6 +48,7 @@ build-disk-image:
 		--security-opt=label=disable \
 		--device=/dev/kvm \
 		--volume "$$STORAGE_PATH:$$STORAGE_PATH" \
+		$$LOG_VOLUME \
 		--build-arg STORAGE_PATH="$$STORAGE_PATH" \
 		--build-arg FEDORA_VERSION="$(FEDORA_VERSION)" \
 		--build-arg BOOTC_IMAGE="$(BOOTC_IMAGE)" \
@@ -93,4 +100,5 @@ help:
 	@echo "  FEDORA_VERSION   - Fedora version (default: $(FEDORA_VERSION))"
 	@echo "  DISK_SIZE        - VM disk size (default: $(DISK_SIZE))"
 	@echo "  BUILD_MEMORY     - Memory for bcvk build (default: $(BUILD_MEMORY))"
+	@echo "  BUILD_LOG_DIR    - Host path to collect bcvk logs (default: none)"
 	@echo "  BCVK_EXTRA_ARGS  - Extra arguments passed to bcvk to-disk (default: none)"


### PR DESCRIPTION
This PR fixes 2 CI issues. It sets the permission on the `/dev/kvm` and increases the limit for the file descriptors. Additioanlly, it also enhance the log for the build-image by adding the logs of the journal and console for the bcvk VM
