### PR TITLE
Include fix for bcvk

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,6 +113,12 @@ jobs:
           name: bootc-image-${{ matrix.kube-minor }}
           path: bootc-image.tar
 
+      - name: Print bootc image digest
+        working-directory: node-images/fedora
+        run: |
+          BOOTC_IMAGE=$(make -s print-bootc-image KUBE_MINOR=${{ matrix.kube-minor }})
+          sudo podman inspect --format '{{.Digest}}' ${BOOTC_IMAGE}
+
       - name: Build disk image
         working-directory: node-images/fedora
         run: sudo make build-disk-image KUBE_MINOR=${{ matrix.kube-minor }}

--- a/node-images/fedora/Containerfile.disk
+++ b/node-images/fedora/Containerfile.disk
@@ -9,7 +9,7 @@ RUN git clone https://github.com/bootc-dev/bcvk.git /bcvk && \
     cargo build --release --manifest-path /bcvk/Cargo.toml
 
 FROM quay.io/fedora/fedora-minimal:${FEDORA_VERSION} AS builder
-RUN dnf install -y --setopt=install_weak_deps=0 qemu-kvm qemu-img virtiofsd podman binutils && dnf clean all
+RUN dnf install -y --setopt=install_weak_deps=0 qemu-kvm qemu-img virtiofsd podman binutils openssh && dnf clean all
 COPY --from=bcvk-builder /bcvk/target/release/bcvk /usr/local/bin/bcvk
 RUN printf '[containers]\nnetns="host"\ncgroups="disabled"\n[engine]\ncgroup_manager="cgroupfs"\n' \
     > /etc/containers/containers.conf

--- a/node-images/fedora/Containerfile.disk
+++ b/node-images/fedora/Containerfile.disk
@@ -9,7 +9,7 @@ RUN git clone https://github.com/bootc-dev/bcvk.git /bcvk && \
     cargo build --release --manifest-path /bcvk/Cargo.toml
 
 FROM quay.io/fedora/fedora-minimal:${FEDORA_VERSION} AS builder
-RUN dnf install -y --setopt=install_weak_deps=0 qemu-kvm qemu-img podman binutils && dnf clean all
+RUN dnf install -y --setopt=install_weak_deps=0 qemu-kvm qemu-img virtiofsd podman binutils && dnf clean all
 COPY --from=bcvk-builder /bcvk/target/release/bcvk /usr/local/bin/bcvk
 RUN printf '[containers]\nnetns="host"\ncgroups="disabled"\n[engine]\ncgroup_manager="cgroupfs"\n' \
     > /etc/containers/containers.conf

--- a/node-images/fedora/Containerfile.disk
+++ b/node-images/fedora/Containerfile.disk
@@ -27,6 +27,7 @@ RUN mkdir -p /output ${LOG_DIR} && \
     bcvk to-disk -K \
     --karg 'console=tty0' \
     --karg 'console=ttyS0,115200n8' \
+    --karg 'console=hvc0' \
     --filesystem ext4 \
     --format qcow2 \
     --memory ${MEMORY} \

--- a/node-images/fedora/Containerfile.disk
+++ b/node-images/fedora/Containerfile.disk
@@ -1,7 +1,16 @@
 ARG FEDORA_VERSION=44
+ARG BCVK_REF=main
+
+FROM quay.io/fedora/fedora-minimal:${FEDORA_VERSION} AS bcvk-builder
+ARG BCVK_REF
+RUN dnf install -y --setopt=install_weak_deps=0 git rust cargo && dnf clean all
+RUN git clone https://github.com/bootc-dev/bcvk.git /bcvk && \
+    git -C /bcvk checkout ${BCVK_REF} && \
+    cargo build --release --manifest-path /bcvk/Cargo.toml
 
 FROM quay.io/fedora/fedora-minimal:${FEDORA_VERSION} AS builder
-RUN dnf install -y --setopt=install_weak_deps=0 qemu-kvm podman bcvk binutils && dnf clean all
+RUN dnf install -y --setopt=install_weak_deps=0 qemu-kvm qemu-img podman binutils && dnf clean all
+COPY --from=bcvk-builder /bcvk/target/release/bcvk /usr/local/bin/bcvk
 RUN printf '[containers]\nnetns="host"\ncgroups="disabled"\n[engine]\ncgroup_manager="cgroupfs"\n' \
     > /etc/containers/containers.conf
 

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -6,6 +6,7 @@ DISK_SIZE ?= 10G
 BUILD_MEMORY ?= 4G
 BUILD_LOG_DIR ?= /tmp/bcvk-logs
 BCVK_EXTRA_ARGS ?=
+BCVK_REF ?= 9005a6111f62533cb7b8b6a3cdffe6e1e98ce673
 
 IMAGE_TAG ?= v$(KUBE_MINOR)-fedora-$(FEDORA_VERSION)
 REGISTRY ?= ghcr.io/bootc-dev/bink
@@ -58,6 +59,7 @@ build-disk-image:
 		--build-arg KUBE_MINOR="$(KUBE_MINOR)" \
 		--build-arg BOOTC_DIGEST="$$BOOTC_DIGEST" \
 		--build-arg BCVK_EXTRA_ARGS="$(BCVK_EXTRA_ARGS)" \
+		--build-arg BCVK_REF="$(BCVK_REF)" \
 		-t $(NODE_IMAGE) \
 		-f Containerfile.disk \
 		.
@@ -103,3 +105,4 @@ help:
 	@echo "  BUILD_MEMORY     - Memory for bcvk build (default: $(BUILD_MEMORY))"
 	@echo "  BUILD_LOG_DIR    - Host path to collect bcvk logs (default: none)"
 	@echo "  BCVK_EXTRA_ARGS  - Extra arguments passed to bcvk to-disk (default: none)"
+	@echo "  BCVK_REF         - Git commit/tag to build bcvk from source (default: $(BCVK_REF))"


### PR DESCRIPTION
Include fix in bcvk: https://github.com/bootc-dev/bcvk/pull/313. Also, install virtiofs and openssl dependencies and enable hvc0 console.

This should hopefully fix https://github.com/bootc-dev/bootc-operator/issues/136 . Since now the digest printed by the node images matches with the one use by bootc into the bcvk VM