### PR TITLE
ci: set default Kubernetes version dynamically via Makefile

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Get supported Kubernetes versions
         id: set-matrix
         run: |
-          DEFAULT="1.35"
+          DEFAULT=$(make -s -C node-images/fedora print-kube-minor)
           FEDORA_VERSION="44"
           ALL=$(curl -s https://endoflife.date/api/kubernetes.json | \
             jq -c '[.[] | select(.eol > (now | strftime("%Y-%m-%d"))) | .cycle][:3]')

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-bootc-image build-disk-image build-disk-image-composefs clean help
+.PHONY: build-bootc-image build-disk-image build-disk-image-composefs print-kube-minor clean help
 
 KUBE_MINOR ?= 1.35
 FEDORA_VERSION ?= 44
@@ -81,6 +81,9 @@ print-node-image:
 
 print-node-image-composefs:
 	@echo $(NODE_IMAGE_COMPOSEFS)
+
+print-kube-minor:
+	@echo $(KUBE_MINOR)
 
 clean:
 	@echo "=== Cleaning up ==="


### PR DESCRIPTION
Previously, the default Kubernetes version (`1.35`) was hardcoded in `.github/workflows/integration-tests.yml`. This created duplication with `node-images/fedora/Makefile` where `KUBE_MINOR ?= 1.35` is defined.

This PR makes `node-images/fedora/Makefile` the single source of truth for `KUBE_MINOR`:
1. Adds `print-kube-minor` target to `.PHONY` in `node-images/fedora/Makefile`.
2. Updates `integration-tests.yml` to dynamically query `DEFAULT=$(make -s -C node-images/fedora print-kube-minor)`.

Fixes #87