### PR TITLE
nodes-image: build bcvk from branch

### DIFF
--- a/node-images/fedora/Containerfile.disk
+++ b/node-images/fedora/Containerfile.disk
@@ -3,8 +3,11 @@ ARG BCVK_REF=main
 
 FROM quay.io/fedora/fedora-minimal:${FEDORA_VERSION} AS bcvk-builder
 ARG BCVK_REF
-RUN dnf install -y --setopt=install_weak_deps=0 git rust cargo && dnf clean all
-RUN git clone https://github.com/bootc-dev/bcvk.git /bcvk && \
+RUN dnf install -y --setopt=install_weak_deps=0 git rust cargo openssl-devel pkg-config && dnf clean all
+# TODO: currently, there is a bug in bcvk where the digest for the image
+# doesn't match with the remote digest. A temporary fix is available at this
+# repository. See: https://github.com/bootc-dev/bcvk/pull/314
+RUN git clone https://github.com/Johan-Liebert1/bcvk.git /bcvk && \
     git -C /bcvk checkout ${BCVK_REF} && \
     cargo build --release --manifest-path /bcvk/Cargo.toml
 

--- a/node-images/fedora/Makefile
+++ b/node-images/fedora/Makefile
@@ -6,7 +6,10 @@ DISK_SIZE ?= 10G
 BUILD_MEMORY ?= 4G
 BUILD_LOG_DIR ?= /tmp/bcvk-logs
 BCVK_EXTRA_ARGS ?=
-BCVK_REF ?= 9005a6111f62533cb7b8b6a3cdffe6e1e98ce673
+# TODO: currently, there is a bug in bcvk where the digest for the image
+# doesn't match with the remote digest. A temporary fix is available at this
+# branch
+BCVK_REF ?= img-to-install-cli-opt
 
 IMAGE_TAG ?= v$(KUBE_MINOR)-fedora-$(FEDORA_VERSION)
 REGISTRY ?= ghcr.io/bootc-dev/bink


### PR DESCRIPTION
Currently, there is a bug in bcvk/bootc where the remote digest isn't properly reported and this cause a failure in bootc-operator CI since the remote digest doesn't match with the one reported by bootc status.

A temporary fix is available at
https://github.com/bootc-dev/bcvk/pull/314 and we now build bcvk from that branch.