### PR TITLE
Another try to fix the bootc digest report

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,12 +113,6 @@ jobs:
           name: bootc-image-${{ matrix.kube-minor }}
           path: bootc-image.tar
 
-      - name: Print bootc image digest
-        working-directory: node-images/fedora
-        run: |
-          BOOTC_IMAGE=$(make -s print-bootc-image KUBE_MINOR=${{ matrix.kube-minor }})
-          sudo podman inspect --format '{{.Digest}}' ${BOOTC_IMAGE}
-
       - name: Build disk image
         working-directory: node-images/fedora
         run: sudo make build-disk-image KUBE_MINOR=${{ matrix.kube-minor }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -321,7 +321,14 @@ jobs:
           podman volume prune -f 2>/dev/null || true
 
   push-node-images:
-    needs: [supported-versions, build-node-images, integration-tests, integration-tests-composefs, integration-tests-k8s-versions]
+    needs:
+      [
+        supported-versions,
+        build-node-images,
+        integration-tests,
+        integration-tests-composefs,
+        integration-tests-k8s-versions,
+      ]
     if: >-
       needs.build-node-images.result == 'success' &&
       (github.event_name == 'push' || inputs.push-node-images == true)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -89,6 +89,9 @@ jobs:
           sudo chmod 666 /dev/kvm
           ls -la /dev/kvm
 
+      - name: Start local registry
+        run: sudo podman run -d -p 5000:5000 --name registry docker.io/library/registry:2
+
       - name: Build bootc image
         working-directory: node-images/fedora
         run: sudo make build-bootc-image KUBE_MINOR=${{ matrix.kube-minor }}
@@ -100,6 +103,22 @@ jobs:
           TAG=$(make -s print-image-tag KUBE_MINOR=${{ matrix.kube-minor }})
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Image tag: ${TAG}"
+
+      - name: Push bootc image to local registry
+        working-directory: node-images/fedora
+        run: |
+          BOOTC_SRC=$(make -s print-bootc-image KUBE_MINOR=${{ matrix.kube-minor }})
+          sudo podman tag ${BOOTC_SRC} localhost:5000/node:${{ steps.meta.outputs.tag }}
+          sudo podman push --tls-verify=false localhost:5000/node:${{ steps.meta.outputs.tag }}
+
+      - name: Pull bootc image from local registry
+        working-directory: node-images/fedora
+        run: |
+          BOOTC_SRC=$(make -s print-bootc-image KUBE_MINOR=${{ matrix.kube-minor }})
+          sudo podman rmi ${BOOTC_SRC} || true
+          sudo podman pull --tls-verify=false localhost:5000/node:${{ steps.meta.outputs.tag }}
+          sudo podman tag localhost:5000/node:${{ steps.meta.outputs.tag }} ${BOOTC_SRC}
+          echo "Bootc image digest: $(sudo podman inspect --format '{{.Digest}}' ${BOOTC_SRC})"
 
       - name: Save bootc image
         working-directory: node-images/fedora

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -389,7 +389,6 @@ jobs:
         run: sudo podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: Push bootc image
-        id: push-bootc
         working-directory: node-images/fedora
         run: |
           TAG=${{ steps.meta.outputs.tag }}
@@ -397,28 +396,11 @@ jobs:
           PUSH_DEST=${{ env.PUSH_REGISTRY }}/${{ env.PUSH_IMAGE }}
 
           sudo podman tag ${BOOTC_SRC} ${PUSH_DEST}:${TAG}
-          sudo podman push --digestfile=/tmp/bootc-digest ${PUSH_DEST}:${TAG}
+          sudo podman push ${PUSH_DEST}:${TAG}
           if [ "${{ matrix.kube-minor }}" = "${{ needs.supported-versions.outputs.default-version }}" ]; then
             sudo podman tag ${BOOTC_SRC} ${PUSH_DEST}:latest
             sudo podman push ${PUSH_DEST}:latest
           fi
-
-          BOOTC_DIGEST=$(cat /tmp/bootc-digest)
-          echo "digest=${BOOTC_DIGEST}" >> "$GITHUB_OUTPUT"
-          echo "Bootc registry digest: ${BOOTC_DIGEST}"
-
-      - name: Fix bootc digest label in disk images
-        run: |
-          BOOTC_DIGEST=${{ steps.push-bootc.outputs.digest }}
-          DISK_SRC=$(make -s -C node-images/fedora print-node-image KUBE_MINOR=${{ matrix.kube-minor }})
-          DISK_COMPOSEFS_SRC=$(make -s -C node-images/fedora print-node-image-composefs KUBE_MINOR=${{ matrix.kube-minor }})
-
-          for IMG in "${DISK_SRC}" "${DISK_COMPOSEFS_SRC}"; do
-            CTR=$(sudo buildah from "${IMG}")
-            sudo buildah config --label "bink.bootc-image-digest=${BOOTC_DIGEST}" "${CTR}"
-            sudo buildah commit "${CTR}" "${IMG}"
-            sudo buildah rm "${CTR}"
-          done
 
       - name: Push disk image
         working-directory: node-images/fedora


### PR DESCRIPTION
This PR adds a new staging step to push the node image before building the disk images. In this way, we can repull it and have the correct remote digest in the spec and in the container storage. In this way, bootc should be able to select the correct digest during the bcvk build