### PR TITLE
Fix node list all flag

### DIFF
--- a/internal/cli/node/list.go
+++ b/internal/cli/node/list.go
@@ -68,6 +68,10 @@ func runList(ctx context.Context, logger *logrus.Logger, showAll bool) error {
 
 		state = strings.TrimSpace(state)
 
+		if !showAll && state != "running" {
+			continue
+		}
+
 		created, err := podmanClient.ContainerInspect(ctx, containerName, "{{.Created}}")
 		if err == nil {
 			created = strings.TrimSpace(created)


### PR DESCRIPTION
closes: https://github.com/bootc-dev/bink/issues/126

What I did:
```
harshwardhan:~/Downloads/repos/bink$ ./bink node list --cluster-name test
Found 1 cluster node(s):

  ✓ node1 (role: control-plane, status: running, created: 2026-08-24 10:49:22)

harshwardhan:~/Downloads/repos/bink$ ./bink node list --cluster-name test --all
Found 2 cluster node(s):

  ✓ node1 (role: control-plane, status: running, created: 2026-08-24 10:49:22)
  ✗ node2 (role: worker, status: exited, created: 2026-08-24 10:51:33)
```