### PR TITLE
gha: use static list for supported kubernetes versions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,8 +65,8 @@ jobs:
         run: |
           DEFAULT="1.35"
           FEDORA_VERSION="44"
-          ALL=$(curl -s https://endoflife.date/api/kubernetes.json | \
-            jq -c '[.[] | select(.eol > (now | strftime("%Y-%m-%d"))) | .cycle][:3]')
+          # TODO: check how to configure renovate to update this list automatically
+          ALL='["1.36", "1.35", "1.34"]'
           NON_DEFAULT=$(echo "$ALL" | jq -c --arg default "$DEFAULT" 'map(select(. != $default))')
           # Construct the staging branch tag based on the branch name that is suitable for container image
           # tags. It converts all the character to lower cases, and replaces all non lower cases letter, numbers, '.'


### PR DESCRIPTION
If we always dynamically fetch the kubernetes version, when there is a new release, we haven't built the corresponding node image yet. Additionally, from the past experience, it is better to control the version we test since it might introduce regressions on all the PR. Therefore, before updating to a new version, we want to test it in the PR that bumps the version.